### PR TITLE
add python version in build string

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
   git_rev: v{{ version }}
 
 build:
-  number: 1
-  string: cuda{{ cudatoolkit | replace(".*", "") }}_{{ PKG_BUILDNUM }}
+  number: 2
+  string: cuda{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_{{ PKG_BUILDNUM }}
   script: DS_BUILD_SPARSE_ATTN=0; DS_BUILD_OPS=1; {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   script_env:
     - CUDA_HOME


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

`deepspeed` package should have python version in the build string so that it gets built for each py version.
Presently it is being generated for single python version and import of deepspeed fails in an environment for any other python version. 

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
